### PR TITLE
Add vpn operations

### DIFF
--- a/live_tests/test_vpn.py
+++ b/live_tests/test_vpn.py
@@ -1,0 +1,24 @@
+import os
+import sys
+import unittest
+import time
+import packet
+
+
+class TestVpn(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        self.manager = packet.Manager(auth_token=os.environ['PACKET_TOKEN'])
+        self.manager.turn_on_vpn()
+
+    def test_get_vpn_config(self):
+        config = self.manager.get_vpn_configuration("ewr1")
+        print config
+
+    @classmethod
+    def tearDownClass(self):
+        self.manager.turn_off_vpn()
+
+
+if __name__ == "__main__":
+    sys.exit(unittest.main())

--- a/packet/Manager.py
+++ b/packet/Manager.py
@@ -381,3 +381,14 @@ class Manager(BaseAPI):
             events.append(Event(e))
 
         return events
+
+    def get_vpn_configuration(self, facilityCode):
+        params = {"code": facilityCode}
+        data = self.call_api("user/vpn", type="GET", params=params)
+        return data
+
+    def turn_on_vpn(self):
+        return self.call_api("user/vpn", type="POST")
+
+    def turn_off_vpn(self):
+        return self.call_api("user/vpn", type="DELETE")


### PR DESCRIPTION
Test fails because the enable VPN endpoint returns an error